### PR TITLE
Yoke and muon chambers fix

### DIFF
--- a/FCCee/FCCee_o5_v02/FCCee_o5_v02.xml
+++ b/FCCee/FCCee_o5_v02/FCCee_o5_v02.xml
@@ -345,8 +345,8 @@
 
     <include ref="Solenoid_o1_v01_02.xml"/>
 
-    <include ref="YokeBarrel_o1_v01_01.xml"/>
-    <include ref="YokeEndcap_o1_v01_01.xml"/>
+    <include ref="YokeBarrel_o1_v01_02.xml"/>
+    <include ref="YokeEndcap_o1_v01_02.xml"/>
 
 
     <plugins>

--- a/FCCee/FCCee_o5_v02/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/FCCee_o5_v02/YokeBarrel_o1_v01_02.xml
@@ -58,7 +58,7 @@
                 <slice material="Air" thickness="0.35*cm" />
                 <slice material="Aluminium" thickness="0.1*cm" />
                 <slice material="Air" thickness="1.0*cm" />
-                <slice material="Iron" thickness="24.4*cm" vis="YokeAbsorberVis" radiator="yes"/>
+                <slice material="Iron" thickness="17.7*cm" vis="YokeAbsorberVis" radiator="yes"/>
             </layer>
             
 

--- a/FCCee/FCCee_o5_v02/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/FCCee_o5_v02/YokeEndcap_o1_v01_02.xml
@@ -35,7 +35,7 @@
             
             <dimensions nsides_inner="YokeEndcap_outer_symmetry" nsides_outer="YokeEndcap_outer_symmetry" zmin="YokeEndcap_min_z" rmin="YokeEndcap_inner_radius" rmax="YokeEndcap_outer_radius"/>
             <layer repeat="6" vis="YokeEndcapLayerVis">
-                <slice material="Iron" thickness="19.7*cm"  vis="YokeAbsorberVis" radiator="yes"/>
+                <slice material="Iron" thickness="21*cm"  vis="YokeAbsorberVis" radiator="yes"/>
                 <slice material="Aluminium" thickness="0.1*cm" />
                 <slice material="Air" thickness="0.35*cm" />
                 <slice material="PyrexGlass" thickness="0.2*cm" />
@@ -52,7 +52,7 @@
                 <slice material="Aluminium" thickness="0.1*cm" />
             </layer>
             <layer repeat="1" vis="YokeEndcapLayerVis">
-                <slice material="Iron" thickness="9.8*cm"  vis="YokeAbsorberVis" radiator="yes"/>
+                <slice material="Iron" thickness="10.5*cm"  vis="YokeAbsorberVis" radiator="yes"/>
             </layer>
         </detector>
         


### PR DESCRIPTION
- Change thickness of the Iron layer in the barrel and endcaps yoke to match FCCee specifications